### PR TITLE
Update mailer from address

### DIFF
--- a/spec/lib/tasks/dashboards_spec.rb
+++ b/spec/lib/tasks/dashboards_spec.rb
@@ -56,7 +56,7 @@ describe "Dashboards Rake" do
         run_rake_task
         email = open_last_email
 
-        expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
+        expect(email).to deliver_from("CONSUL <participa@lorca.es>")
         expect(email).to deliver_to(proposal.author)
         expect(email).to have_subject("More news about your citizen proposal")
       end
@@ -69,7 +69,7 @@ describe "Dashboards Rake" do
         run_rake_task
         email = open_last_email
 
-        expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
+        expect(email).to deliver_from("CONSUL <participa@lorca.es>")
         expect(email).to deliver_to(proposal.author)
         expect(email).to have_subject("More news about your citizen proposal")
       end

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -33,7 +33,7 @@ describe Dashboard::Mailer do
 
       email = open_last_email
 
-      expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
+      expect(email).to deliver_from("CONSUL <participa@lorca.es>")
       expect(email).to deliver_to(proposal.author)
       expect(email).to have_subject(proposal.title)
       expect(email).to have_body_text("Support this proposal")
@@ -74,7 +74,7 @@ describe Dashboard::Mailer do
 
         email = open_last_email
 
-        expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
+        expect(email).to deliver_from("CONSUL <participa@lorca.es>")
         expect(email).to deliver_to(proposal.author)
         expect(email).to have_subject("More news about your citizen proposal")
         expect(email).to have_body_text("Hello #{proposal.author.name},")
@@ -116,7 +116,7 @@ describe Dashboard::Mailer do
 
         email = open_last_email
 
-        expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
+        expect(email).to deliver_from("CONSUL <participa@lorca.es>")
         expect(email).to deliver_to(proposal.author)
         expect(email).to have_subject("More news about your citizen proposal")
         expect(email).to have_body_text("Hello #{proposal.author.name},")
@@ -171,7 +171,7 @@ describe Dashboard::Mailer do
 
       email = open_last_email
 
-      expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
+      expect(email).to deliver_from("CONSUL <participa@lorca.es>")
       expect(email).to deliver_to(proposal.author)
       expect(email).to have_subject("Your draft citizen proposal is created")
       expect(email).to have_body_text("Hi #{proposal.author.name}!")
@@ -235,7 +235,7 @@ describe Dashboard::Mailer do
 
       email = open_last_email
 
-      expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
+      expect(email).to deliver_from("CONSUL <participa@lorca.es>")
       expect(email).to deliver_to(proposal.author)
       expect(email).to have_subject("Your citizen proposal is already "\
                                     "published. Don't stop spreading!")


### PR DESCRIPTION
## References

After changing the default from address at [PR #2](https://github.com/AyuntamientoLorca/consul/pull/2) some tests started to  fail.

## Objectives

Update affected specs to fix the test suite.