### PR TITLE
Setup mailer default settings on tests

### DIFF
--- a/spec/lib/tasks/dashboards_spec.rb
+++ b/spec/lib/tasks/dashboards_spec.rb
@@ -48,6 +48,11 @@ describe "Dashboards Rake" do
       let!(:action)   { create(:dashboard_action, :proposed_action, :active, day_offset: 0) }
       let!(:resource) { create(:dashboard_action, :resource, :active, day_offset: 0) }
 
+      before do
+        Setting["mailer_from_name"] = "CONSUL"
+        Setting["mailer_from_address"] = "noreply@consul.dev"
+      end
+
       it " when there are news actions actived for published proposals" do
         proposal = create(:proposal)
         action.update!(published_proposal: true)

--- a/spec/lib/tasks/dashboards_spec.rb
+++ b/spec/lib/tasks/dashboards_spec.rb
@@ -56,7 +56,7 @@ describe "Dashboards Rake" do
         run_rake_task
         email = open_last_email
 
-        expect(email).to deliver_from("CONSUL <participa@lorca.es>")
+        expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
         expect(email).to deliver_to(proposal.author)
         expect(email).to have_subject("More news about your citizen proposal")
       end
@@ -69,7 +69,7 @@ describe "Dashboards Rake" do
         run_rake_task
         email = open_last_email
 
-        expect(email).to deliver_from("CONSUL <participa@lorca.es>")
+        expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
         expect(email).to deliver_to(proposal.author)
         expect(email).to have_subject("More news about your citizen proposal")
       end

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -11,6 +11,8 @@ describe Dashboard::Mailer do
 
   before do
     Setting["feature.dashboard.notification_emails"] = true
+    Setting["mailer_from_name"] = "CONSUL"
+    Setting["mailer_from_address"] = "noreply@consul.dev"
   end
 
   describe "#forward" do

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -33,7 +33,7 @@ describe Dashboard::Mailer do
 
       email = open_last_email
 
-      expect(email).to deliver_from("CONSUL <participa@lorca.es>")
+      expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
       expect(email).to deliver_to(proposal.author)
       expect(email).to have_subject(proposal.title)
       expect(email).to have_body_text("Support this proposal")
@@ -74,7 +74,7 @@ describe Dashboard::Mailer do
 
         email = open_last_email
 
-        expect(email).to deliver_from("CONSUL <participa@lorca.es>")
+        expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
         expect(email).to deliver_to(proposal.author)
         expect(email).to have_subject("More news about your citizen proposal")
         expect(email).to have_body_text("Hello #{proposal.author.name},")
@@ -116,7 +116,7 @@ describe Dashboard::Mailer do
 
         email = open_last_email
 
-        expect(email).to deliver_from("CONSUL <participa@lorca.es>")
+        expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
         expect(email).to deliver_to(proposal.author)
         expect(email).to have_subject("More news about your citizen proposal")
         expect(email).to have_body_text("Hello #{proposal.author.name},")
@@ -171,7 +171,7 @@ describe Dashboard::Mailer do
 
       email = open_last_email
 
-      expect(email).to deliver_from("CONSUL <participa@lorca.es>")
+      expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
       expect(email).to deliver_to(proposal.author)
       expect(email).to have_subject("Your draft citizen proposal is created")
       expect(email).to have_body_text("Hi #{proposal.author.name}!")
@@ -235,7 +235,7 @@ describe Dashboard::Mailer do
 
       email = open_last_email
 
-      expect(email).to deliver_from("CONSUL <participa@lorca.es>")
+      expect(email).to deliver_from("CONSUL <noreply@consul.dev>")
       expect(email).to deliver_to(proposal.author)
       expect(email).to have_subject("Your citizen proposal is already "\
                                     "published. Don't stop spreading!")


### PR DESCRIPTION
## References
Replace the solution from #8 with a [commit](https://github.com/consul/consul/commit/df280ffbfe1) that fixes this problem at main repository.

## Objectives

Setup the default mailer settings `mailer_from_address` and `mailer_from_name` on affected specs, so there is no need to update the specs anymore when a fork overrides the default mailer settings.