### PR TITLE
Do not use custom prefix to load custom images

### DIFF
--- a/app/views/custom/welcome/index.html.erb
+++ b/app/views/custom/welcome/index.html.erb
@@ -8,7 +8,7 @@
 
   <div class="row">
     <div class="small-12 medium-12 large-12">
-      <%= image_tag "custom/portada.jpg", class: "img_portada", alt: "En mi barrio decido yo. Llega la red social municipal en la que tú tienes el mando" %>
+      <%= image_tag "portada.jpg", class: "img_portada", alt: "En mi barrio decido yo. Llega la red social municipal en la que tú tienes el mando" %>
     </div>
 <!--
   <iframe width="100%" height="550" src="https://www.youtube.com/embed/x1Vl1XrJFR8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
## References
Related Pull Request: Portada #25 

## Objectives
As custom folder assets are already prepended to other assets there is no need to specify the custom folder.

## Visual Changes

**Before**
<img width="1199" alt="Portada image not found" src="https://user-images.githubusercontent.com/15726/123946908-0235b100-d9a0-11eb-9d68-94c09616a898.png">

**After**
<img width="1092" alt="Portada-fixed" src="https://user-images.githubusercontent.com/15726/123946921-06fa6500-d9a0-11eb-8a50-287b564cf63a.png">

## Notes
Tested successfully on a virtual production server.
